### PR TITLE
fix never closing when jabber stopped

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,10 @@ function run(config) {
 
     // Register the event listeners for handling requests
     stdin.on('data', handleIncomingData);
+	stdin.on('exit', function(){
+		doLog('info', 'Received end on stdin, shutting down');
+		process.exit(255);
+	});
 
     process.on('exit', function() {
         doLog('info', 'Auth process is shutting down.');


### PR DESCRIPTION
Under debian when stopping the `ejabberd` service.
process does not receive `exit` but `stdin` receive `end`. I don't know if it is the best way to handle it but it needs to be addressed. Otherwise the script is never killed.