### PR TITLE
fix winston crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function sendResult(result) {
 function run(config) {
     // Configure the logger
     if (config && config.log && config.log.filename) {
-        winston.add(winston.transports.File, config.log);
+        winston.add(new winston.transports.File(config.log));
         logEnabled = true;
     }
     // Remove the console transport, since stdout will be used by ejabberd to receive responses


### PR DESCRIPTION
Dependencies where updated without checking for breaking changes
this fixes "Error: Invalid transport, must be an object with a log method." being thrown by winston.